### PR TITLE
First bugfix train (more to come on following days!)

### DIFF
--- a/game/dota_addons/dota_imba/scripts/npc/npc_items_custom.txt
+++ b/game/dota_addons/dota_imba/scripts/npc/npc_items_custom.txt
@@ -712,7 +712,7 @@
 			"02"
 			{
 				"var_type"				"FIELD_INTEGER"
-				"bonus_mana"			"250"
+				"bonus_mana"			"400"
 			}
 			"03"
 			{
@@ -762,7 +762,7 @@
 			"12"
 			{
 				"var_type"				"FIELD_INTEGER"
-				"mend_mana_pct"			"7"
+				"mend_mana_pct"			"10"
 			}
 			"13"
 			{

--- a/game/dota_addons/dota_imba/scripts/vscripts/hero/hero_centaur.lua
+++ b/game/dota_addons/dota_imba/scripts/vscripts/hero/hero_centaur.lua
@@ -220,13 +220,13 @@ function imba_centaur_hoof_stomp:OnSpellStart()
 			elapsed_time = elapsed_time + FrameTime()
 
 			-- Resolve NPCs stuck into one another
-			ResolveNPCPositions(arena_center, radius)
+			ResolveNPCPositions(arena_center, radius)			
 
 			if caster:HasTalent("special_bonus_imba_centaur_3") then
-				arena_center = caster:GetAbsOrigin()
-				for _,enemy in pairs(enemies) do
+				local arena_center = caster:GetAbsOrigin()
+				for _,enemy in pairs(enemies) do					
 					modifier = enemy:FindModifierByName(modifier_arena_debuff)
-					if modifier and not enemy:GetUnitName() == "npc_dota_diretide_easter_egg" then
+					if modifier and enemy:GetUnitName() ~= "npc_dota_diretide_easter_egg" then						
 						modifier.arena_center = arena_center
 					end
 				end
@@ -237,6 +237,7 @@ function imba_centaur_hoof_stomp:OnSpellStart()
 					if distance > caster:FindTalentValue("special_bonus_imba_centaur_3") then
 						caster:RemoveModifierByName(modifier_arena_buff)
 						ParticleManager:DestroyParticle(self.particle_arena_fx,true)
+						ParticleManager:ReleaseParticleIndex(self.particle_arena_fx)
 						return nil
 					end
 				end
@@ -248,6 +249,7 @@ function imba_centaur_hoof_stomp:OnSpellStart()
 				ParticleManager:SetParticleControl(self.particle_arena_fx, 6, caster:GetAbsOrigin())
 				ParticleManager:SetParticleControl(self.particle_arena_fx, 7, caster:GetAbsOrigin())
 			end	
+
 			-- Check caster, if he doesn't have the arena modifier and he's in the arena, give it to him again 
 			if not caster:HasModifier(modifier_arena_buff) then
 				local distance = (caster:GetAbsOrigin() - arena_center):Length2D()

--- a/game/dota_addons/dota_imba/scripts/vscripts/imba.lua
+++ b/game/dota_addons/dota_imba/scripts/vscripts/imba.lua
@@ -912,9 +912,10 @@ function GameMode:DamageFilter( keys )
 
 					-- Find the Reaper's Scythe ability
 					local ability = scythe_caster:FindAbilityByName("imba_necrolyte_reapers_scythe")
-					if not ability then return nil end
-					local mod = victim:AddNewModifier(scythe_caster, ability, "modifier_imba_reapers_scythe_respawn", {})
+					if not ability then return nil end					
 					scythe_modifier:Destroy()
+					victim:AddNewModifier(scythe_caster, ability, "modifier_imba_reapers_scythe_respawn", {})
+
 					-- Attempt to kill the target, crediting it to the caster of Reaper's Scythe
 					ApplyDamage({attacker = scythe_caster, victim = victim, ability = ability, damage = victim:GetHealth() + 10, damage_type = DAMAGE_TYPE_PURE, damage_flag = DOTA_DAMAGE_FLAG_NO_DAMAGE_MULTIPLIERS + DOTA_DAMAGE_FLAG_BYPASSES_BLOCK})
 				end


### PR DESCRIPTION
- Improved Guardian Greaves bonus mana from +250 to +400 (to match Arcane Boots). Mana replenishment on active from 7% to 10% (to match Arcane Boot's active).
- Added a note in Dazzle's Shadow Wave to reflect that the healing scales with spell power.
- Fixed Necrophos' Reaper's Scythe triggering on targets that would reincarnate (Reincarnate, Aegis).
- Fixed Centaur Arena on Wheels not really working. (only visually lul)

Swap the current Shadow Wave tooltips with those below:
https://hastebin.com/eteridefox.pl